### PR TITLE
allow bigint to int

### DIFF
--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -16,7 +16,7 @@ use warnings;
 use utf8;
 use open qw( :std :utf8 );
 
-our $VERSION = '5.5.0';
+our $VERSION = '5.5.1';
 
 use DBI 1.51;                               ## How Perl talks to databases
 use DBD::Pg 2.0   qw( :async             ); ## How Perl talks to Postgres databases
@@ -7193,6 +7193,8 @@ sub validate_sync {
                         or
                         ($scol->{ftype} eq 'integer' and $fcol->{ftype} eq 'bigint')
                         or
+                        ($scol->{$ftype} eq 'bigint' and $fcol->{ftype} eq 'integer' and $ENV{BUCARDO_BIGINT_TO_INT_OK})
+                        or
                         ($scol->{ftype} =~ /^timestamp/ and $fcol->{ftype} =~ /^timestamp/)
                 ) {
                         my $msg = qq{Source database for sync "$syncname" has column "$colname" of table "$t" as type "$scol->{ftype}", but target database "$dbname" has a type of "$fcol->{ftype}". You should really fix that.};
@@ -10486,7 +10488,7 @@ Bucardo - Postgres multi-master replication system
 
 =head1 VERSION
 
-This document describes version 5.5.0 of Bucardo
+This document describes version 5.5.1 of Bucardo
 
 =head1 WEBSITE
 

--- a/Bucardo.pm.html
+++ b/Bucardo.pm.html
@@ -2,12 +2,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<title></title>
+<title>Bucardo - Postgres multi-master replication system</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 
 </head>
 
-<body style="background-color: white">
+<body>
 
 
 
@@ -29,7 +29,7 @@
 
 <h1 id="VERSION">VERSION</h1>
 
-<p>This document describes version 5.5.0 of Bucardo</p>
+<p>This document describes version 5.5.1 of Bucardo</p>
 
 <h1 id="WEBSITE">WEBSITE</h1>
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+Bucardo version 5.5.1
+  - added BUCARD_BIGINT_TO_INT_OK to allow replication from integer columns back
+    to bigint columns.  It is up to PG and the user to ensure the FKs aren't
+    larger than 32 bits.
 
 Bucardo version 5.5.0
 

--- a/META.yml
+++ b/META.yml
@@ -1,6 +1,6 @@
 --- #YAML:1.0
 name                : Bucardo
-version             : 5.5.0
+version             : 5.5.1
 abstract            : Postgres multi-master replication system
 author:              
   - Greg Sabino Mullane <greg@endpoint.com>
@@ -32,10 +32,10 @@ build_requires:
 provides:
   Bucardo:
     file            : Bucardo.pm
-    version         : 5.5.0
+    version         : 5.5.1
   bucardo:
     file            : bucardo
-    version         : 5.5.0
+    version         : 5.5.1
 
 resources:
   homepage          : http://bucardo.org/index.html

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,7 +4,7 @@ use warnings;
 use 5.008003;
 
 ## No version.pm for this one, as the prereqs are not loaded yet.
-my $VERSION = '5.5.0';
+my $VERSION = '5.5.1';
 
 WriteMakefile(
     NAME         => 'Bucardo',

--- a/README
+++ b/README
@@ -4,7 +4,7 @@ Bucardo - a table-based replication system
 DESCRIPTION:
 ------------
 
-This is version 5.5.0 of Bucardo.
+This is version 5.5.1 of Bucardo.
 
 COPYRIGHT:
 ----------

--- a/bucardo
+++ b/bucardo
@@ -31,7 +31,7 @@ Getopt::Long::Configure(qw/ no_ignore_case pass_through no_autoabbrev /);
 
 require I18N::Langinfo;
 
-our $VERSION = '5.5.0';
+our $VERSION = '5.5.1';
 
 ## For the tests, we want to check that it compiles without actually doing anything
 return 1 if $ENV{BUCARDO_TEST};
@@ -10063,7 +10063,7 @@ bucardo - utility script for controlling the Bucardo program
 
 =head1 VERSION
 
-This document describes version 5.5.0 of bucardo
+This document describes version 5.5.1 of bucardo
 
 =head1 USAGE
 
@@ -10615,6 +10615,10 @@ between syncs. If the columns have different names or data types, the
 validation will fail. But perhaps the columns are allowed to have different
 names or data types. If so, disable C<strict_checking> and column differences will
 result in warnings rather than failing the validation. Defaults to true.
+
+Note that if the environment variable C<BUCARD_INT_TO_BIGINT_OK> is set, then
+the code that checks the column types will allow synchronization from C<bigint>
+to C<integer>, which _can_ work if the values do not exceed 32-bit integer values.
 
 =back
 
@@ -11742,7 +11746,7 @@ Which DDL changing conditions do we try to remedy automatically? Default: C<newc
 
 =item C<bucardo_version>
 
-Current version of Bucardo. Default: C<5.5.0>.
+Current version of Bucardo. Default: C<5.5.1>.
 
 =item C<bucardo_vac>
 
@@ -11750,7 +11754,7 @@ Do we want the automatic VAC daemon to run? Default: C<1>.
 
 =item C<bucardo_initial_version>
 
-Bucardo version this schema was created with. Default: C<5.5.0>.
+Bucardo version this schema was created with. Default: C<5.5.1>.
 
 =item C<ctl_checkonkids_time>
 

--- a/bucardo.html
+++ b/bucardo.html
@@ -2,12 +2,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<title></title>
+<title>bucardo - utility script for controlling the Bucardo program</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 
 </head>
 
-<body style="background-color: white">
+<body>
 
 
 
@@ -84,7 +84,7 @@
 
 <h1 id="VERSION">VERSION</h1>
 
-<p>This document describes version 5.5.0 of bucardo</p>
+<p>This document describes version 5.5.1 of bucardo</p>
 
 <h1 id="USAGE">USAGE</h1>
 
@@ -208,7 +208,7 @@
 <p>Deactivates one or more named syncs.</p>
 
 </dd>
-<dt id="message-body"><code>message '&lt;body&gt;'</code></dt>
+<dt id="message-body"><code>message &#39;&lt;body&gt;&#39;</code></dt>
 <dd>
 
 <p>Sends a message to the running Bucardo logs.</p>
@@ -539,7 +539,7 @@
 <dt id="dbname1"><code>dbname</code></dt>
 <dd>
 
-<p>The actual name of the database. Required unless using a service file.</p>
+<p>The actual name of the database. Required unless using a service file or setting it via dbdsn.</p>
 
 </dd>
 <dt id="type"><code>type</code></dt>
@@ -574,6 +574,12 @@
 
 </li>
 </ul>
+
+</dd>
+<dt id="dbdsn"><code>dbdsn</code></dt>
+<dd>
+
+<p>A direct DSN to connect to a database. Will override all other connection options if set.</p>
 
 </dd>
 <dt id="user"><code>user</code></dt>
@@ -728,6 +734,8 @@
 <dd>
 
 <p>Boolean indicating whether or not to be strict when comparing the table between syncs. If the columns have different names or data types, the validation will fail. But perhaps the columns are allowed to have different names or data types. If so, disable <code>strict_checking</code> and column differences will result in warnings rather than failing the validation. Defaults to true.</p>
+
+<p>Note that if the environment variable <code>BUCARD_INT_TO_BIGINT_OK</code> is set, then the code that checks the column types will allow synchronization from <code>bigint</code> to <code>integer</code>, which _can_ work if the values do not exceed 32-bit integer values.</p>
 
 </dd>
 </dl>
@@ -1624,6 +1632,12 @@
 <dd>
 
 </dd>
+<dt id="dbdsn1"><code>dbdsn</code></dt>
+<dd>
+
+<p>A direct DSN to connect to a database. Will override all other connection options if set.</p>
+
+</dd>
 <dt id="user1"><code>user</code></dt>
 <dd>
 
@@ -1803,18 +1817,6 @@
 <dd>
 
 <p>The rows on the &quot;target&quot; database always win.</p>
-
-</dd>
-<dt id="bucardo_skip1"><code>bucardo_skip</code></dt>
-<dd>
-
-<p>Any conflicting rows are simply not replicated. Not recommended for most cases.</p>
-
-</dd>
-<dt id="bucardo_random1"><code>bucardo_random</code></dt>
-<dd>
-
-<p>Each database has an equal chance of winning each time.</p>
 
 </dd>
 <dt id="bucardo_latest1"><code>bucardo_latest</code></dt>
@@ -2122,7 +2124,7 @@
 <dt id="bucardo_version"><code>bucardo_version</code></dt>
 <dd>
 
-<p>Current version of Bucardo. Default: <code>5.5.0</code>.</p>
+<p>Current version of Bucardo. Default: <code>5.5.1</code>.</p>
 
 </dd>
 <dt id="bucardo_vac"><code>bucardo_vac</code></dt>
@@ -2134,7 +2136,7 @@
 <dt id="bucardo_initial_version"><code>bucardo_initial_version</code></dt>
 <dd>
 
-<p>Bucardo version this schema was created with. Default: <code>5.5.0</code>.</p>
+<p>Bucardo version this schema was created with. Default: <code>5.5.1</code>.</p>
 
 </dd>
 <dt id="ctl_checkonkids_time"><code>ctl_checkonkids_time</code></dt>
@@ -2399,9 +2401,9 @@
 
 <h2 id="show">show</h2>
 
-<pre><code>  bucardo show all|&lt;setting&gt; [&lt;setting&gt;...]</code></pre>
+<pre><code>  bucardo show all|changed|&lt;setting&gt; [&lt;setting&gt;...]</code></pre>
 
-<p>Shows the current Bucardo settings. Use the keyword &quot;all&quot; to see all the settings, or specify one or more search terms. See <a href="#set">&quot;set&quot;</a> for complete details on the configuration settings.</p>
+<p>Shows the current Bucardo settings. Use the keyword &quot;all&quot; to see all the settings, &quot;changed&quot; to see settings different than the installed defaults, or specify one or more search terms. See <a href="#set">&quot;set&quot;</a> for complete details on the configuration settings.</p>
 
 <h2 id="config">config</h2>
 

--- a/bucardo.schema
+++ b/bucardo.schema
@@ -1,6 +1,6 @@
 
 -- Schema for the main Bucardo database
--- Version 5.5.0
+-- Version 5.5.1
 
 -- Should be run as a superuser
 -- This should not need to be run directly: use either
@@ -152,8 +152,8 @@ warning_file|bucardo.warning.log|File containing all log lines starting with "Wa
 COPY bucardo.bucardo_config(name,setting,about)
 FROM STDIN
 WITH DELIMITER '|';
-bucardo_initial_version|5.5.0|Bucardo version this schema was created with
-bucardo_version|5.5.0|Current version of Bucardo
+bucardo_initial_version|5.5.1|Bucardo version this schema was created with
+bucardo_version|5.5.1|Current version of Bucardo
 \.
 
 -- Other settings:


### PR DESCRIPTION
This PR adds a feature to allow synchronization from columns of bigint type back to integer type.  It is enabled with the envar `BUCARDO_BIGINT_TO_INT_OK` being set _(to anything)_.

This envar must be set _before_ bucardo is started on either the source or destination host.