### PR TITLE
Also allow array of integers to array of bigints

### DIFF
--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -7186,6 +7186,7 @@ sub validate_sync {
                     ## Allowed: varchar == text
                     ## Allowed: timestamp* == timestamp*
                     ## Allowed: int == bigint
+                    ## Allowed: int[] == bigint[]
                     if (
                         ($scol->{ftype} eq 'character varying' and $fcol->{ftype} eq 'text')
                         or
@@ -7194,6 +7195,8 @@ sub validate_sync {
                         ($scol->{ftype} eq 'integer' and $fcol->{ftype} eq 'bigint')
                         or
                         ($scol->{ftype} eq 'bigint' and $fcol->{ftype} eq 'integer' and $ENV{BUCARDO_BIGINT_TO_INT_OK})
+                        or
+                        ($scol->{ftype} eq 'bigint[]' and $fcol->{ftype} eq 'integer[]' and $ENV{BUCARDO_BIGINT_TO_INT_OK})
                         or
                         ($scol->{ftype} =~ /^timestamp/ and $fcol->{ftype} =~ /^timestamp/)
                 ) {


### PR DESCRIPTION
This should fix the `validate_sync` failures we were encountering last night, which stemmed from columns of integer arrays (`integer[]`) being transformed into columns of bigint arrays (`bigint[]`).

This PR is an attempt at allowing `integer[] -> bigint[]`, though please feel free to make changes if my syntax is incorrect. 

The logs below were snipped for brevity
```
[01:35:30] MCP   Inspecting source table "public.<>" on database "<>_master"
[01:35:30] MCP    Inspecting target table "public.<>" on database "<>_replica"
[01:35:30] MCP Warning: Source database for sync "<>_migration_sync" has column "<>" of table "public.<>" as type "integer[]", but target database "<>_replica" has a type of "bigint[]"
[01:35:30] MCP Validation of sync <>_migration_sync FAILED
``` 